### PR TITLE
fix deploy to heroku button

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,5 @@
+{
+  "name": "team-pull-requests-bot",
+  "description": "Utilizes the github organization webhook, in order to notify your team mates on slack, whenever a team mate opens up a pull request.",
+  "repository": "https://github.com/freshbooks/team-pull-requests-bot"
+}


### PR DESCRIPTION
The deploy button is broken right now because `app.json` is missing.

![screen shot 2017-04-20 at 10 36 57 am](https://cloud.githubusercontent.com/assets/4744103/25236245/613db1f0-25b5-11e7-8d88-1ee6f9404d91.png)
